### PR TITLE
Update global_vars.py to add self.refs instead of initialising later.

### DIFF
--- a/kicost/global_vars.py
+++ b/kicost/global_vars.py
@@ -105,6 +105,7 @@ class PartGroup(object):
     '''@brief Class to group components.'''
     def __init__(self):
         # None by default, here to avoid try/except in the code
+        self.refs = None
         self.datasheet = None
         self.lifecycle = None
         self.specs = {}  # Miscellaneous data from the queries


### PR DESCRIPTION
In PartGroup currently there is no self.refs, but it gets initialised later in the code, see here,

https://github.com/hildogjr/KiCost/blob/a67877ed721591fafe66a236c1014932967faea2/kicost/edas/tools.py#L159

For better readability and for helping dev tools (linters, autocomplete, etc.) to work properly I believe this commit necessary.